### PR TITLE
Fix null values in older sdb, double-clicking on empty values

### DIFF
--- a/SDBrowser/PgDB/PGImportExport.cs
+++ b/SDBrowser/PgDB/PGImportExport.cs
@@ -234,6 +234,7 @@ namespace SDBrowser
         private void BindTypes(NpgsqlConnection conn)
         {
             var schemaLc = Schema.ToLower();
+            NpgsqlConnection.GlobalTypeMapper.Reset();
             NpgsqlConnection.GlobalTypeMapper.MapComposite<Vector2>($"{schemaLc}.vector2");
             NpgsqlConnection.GlobalTypeMapper.MapComposite<Vector3>($"{schemaLc}.vector3");
             NpgsqlConnection.GlobalTypeMapper.MapComposite<Vector4>($"{schemaLc}.vector4");
@@ -265,7 +266,20 @@ namespace SDBrowser
                             var columnName = FauFau.SDBrowser.SDBrowser.GetTableOrFieldName(table.Columns[index].Id);
 
                             if (field == null) {
-                                writer.WriteNull();
+                                if (!table.IsColumnNullable(table.Columns[index]))
+                                {
+                                    if (fieldType == StaticDB.DBType.Vector2Array)
+                                    {
+                                        writer.Write(new List<Vector2>());
+                                    } else if (fieldType == StaticDB.DBType.Blob)
+                                    {
+                                        writer.Write(new List<byte>());
+                                    }
+                                }
+                                else
+                                {
+                                    writer.WriteNull();
+                                }
                             }
                             else if (IsBasicType(fieldType)) {
                                 if (fieldType == StaticDB.DBType.UShort) {
@@ -419,7 +433,7 @@ namespace SDBrowser
                 StaticDB.DBType.AsciiChar     => "character",
                 StaticDB.DBType.ByteArray     => "bytea",
                 StaticDB.DBType.UShortArray   => "integer[]",
-                StaticDB.DBType.UIntArray     => "bigint]",
+                StaticDB.DBType.UIntArray     => "bigint[]",
                 StaticDB.DBType.HalfMatrix4x3 => "halfmatrix4x3",
                 StaticDB.DBType.Half          => "real",
                 _                             => ""

--- a/SDBrowser/SDBrowser.cs
+++ b/SDBrowser/SDBrowser.cs
@@ -1432,7 +1432,8 @@ namespace FauFau.SDBrowser {
         {
             if (e.ColumnIndex > -1 && e.RowIndex > -1)
             {
-                Clipboard.SetText((string)dgvRows.Rows[e.RowIndex].Cells[e.ColumnIndex].FormattedValue);
+                var value = (string)dgvRows.Rows[e.RowIndex].Cells[e.ColumnIndex].FormattedValue;
+                Clipboard.SetText(string.IsNullOrEmpty(value) ? "-" : value);
 
             }
         }


### PR DESCRIPTION
Noticed that import to db doesnt work for 1297 because of null values in not null `area_polygon` in `clientmissions::MissionWaypoint` and `materials` in `dbsounddata::ReverbMaterialConstraint` in another sdb.
Tried import on various versions and it worked without issues, so I didn't add default values for other types.
Copying empty values to clipboard on double click throws exception, so hyphen is copied instead.
Added `GlobalTypeMapper.Reset()` because otherwise importing two different sdb files would fail on create schema due to duplicated mapping for custom types.